### PR TITLE
New command to add labels to known open bugs, release note section provided in stdout

### DIFF
--- a/src/lasso/issues/issues/RstRddReport.py
+++ b/src/lasso/issues/issues/RstRddReport.py
@@ -179,7 +179,7 @@ class RddReport:
         self._logger = logging.getLogger(__name__)
 
         self._org = org
-        self._gh = GithubConnection.getconnection(token=token)
+        self._gh = GithubConnection.get_connection(token=token)
         self._start_time = start_time
         self._end_time = end_time
         self._build = build

--- a/src/lasso/issues/issues/add_version_label_to_open_bugs.py
+++ b/src/lasso/issues/issues/add_version_label_to_open_bugs.py
@@ -8,6 +8,7 @@ from lasso.issues.github import GithubConnection
 
 COLOR_OF_VERSION_LABELS = "#062C9B"
 
+
 def add_label_to_open_bugs(repo, label_name: str):
     """
     Add a label (str) to the open bugs of a repository.
@@ -16,10 +17,16 @@ def add_label_to_open_bugs(repo, label_name: str):
 
     @param repo: repository from the github3 api
     @param label_name: the name of the label to be added
-    """
 
+    @return: True if at least on bug has been found and labelled
+    """
+    one_found = False
     for issue in repo.issues(state="open", labels=["bug"]):
         issue.add_labels(label_name)
+        one_found = True
+
+    return one_found
+
 
 
 def main():
@@ -39,7 +46,12 @@ def main():
     repo = gh.repository(args.github_org, args.github_repo)
     label = f"open.{args.labelled_version}"
     repo.create_label(label, COLOR_OF_VERSION_LABELS)
-    add_label_to_open_bugs(repo, label)
+    print("Add the following line to your release notes on github:")
+    section_title = "**Known bugs** and possible work arounds"
+    if add_label_to_open_bugs(repo, label):
+        print(f"{section_title}: [known bugs in {args.labelled_version}](https://github.com/{args.github_org}/{args.github_repo}/issues?q=is%3Aissue+label%3Aopen.{args.labelled_version})")
+    else:
+        print(f"{section_title}: no known bugs")
 
 
 if __name__ == "__main__":

--- a/src/lasso/issues/issues/add_version_label_to_open_bugs.py
+++ b/src/lasso/issues/issues/add_version_label_to_open_bugs.py
@@ -37,7 +37,7 @@ def main():
 
     gh = GithubConnection.get_connection(token=args.token)
     repo = gh.repository(args.github_org, args.github_repo)
-    label = f"open.{args.version}"
+    label = f"open.{args.labelled_version}"
     repo.create_label(label, COLOR_OF_VERSION_LABELS)
     add_label_to_open_bugs(repo, label)
 


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
The "known bug" section to be added to the release note is noow also provided in the stdout of the command.



## ⚙️ Test Data and/or Report
One of the following should be included here:
* Reference to regression test included in code (preferred wherever reasonable)
* Attach test data here + outputs of tests

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->


