### PR TITLE
make add_version_label robust to multiple run with the same arguments.

### DIFF
--- a/src/lasso/issues/issues/add_version_label_to_open_bugs.py
+++ b/src/lasso/issues/issues/add_version_label_to_open_bugs.py
@@ -1,31 +1,54 @@
 """Lasso Issues: add version label to open bugs issues."""
 import argparse
+import logging
 
+from github3.exceptions import NotFoundError
 from lasso.issues.argparse import add_standard_arguments
 from lasso.issues.github import GithubConnection
 from lasso.issues.issues.issues import DEFAULT_GITHUB_ORG
 
-# have ever seen the same module name embedded so many time
 
 COLOR_OF_VERSION_LABELS = "#062C9B"
 
+_logger = logging.getLogger(__name__)
 
-def add_label_to_open_bugs(repo, label_name: str):
+
+def add_label_to_open_bugs(repo, label_name: str, dry_run: bool = True):
     """Add a label (str) to the open bugs of a repository.
 
     The label need to be created first.
 
     @param repo: repository from the github3 api
     @param label_name: the name of the label to be added
+    @param dry_run: does not update the issue with new label
 
     @return: True if at least on bug has been found and labelled
     """
     one_found = False
     for issue in repo.issues(state="open", labels=["bug"]):
-        issue.add_labels(label_name)
         one_found = True
+        if not dry_run:
+            issue.add_labels(label_name)
 
     return one_found
+
+
+def create_label_if_not_exists(repo, label: str, color: str):
+    """Create the label in the repo if it does not exist yet.
+
+    @param repo: github3 object
+    @param label: string
+    @param color: string for example #123456
+    @return:
+    """
+    try:
+        repo.label(label)
+        _logger.info("label %s already exist, skip creation.", label)
+        return
+    except NotFoundError:
+        repo.create_label(label, color)
+        _logger.info("label %s has been created.", label)
+        return
 
 
 def main():
@@ -39,16 +62,21 @@ def main():
         help="github repo name",
     )
     parser.add_argument("--token", help="github token.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the release note without creating the label and updating the issues in github.",
+    )
 
     args = parser.parse_args()
 
     gh = GithubConnection.get_connection(token=args.token)
     repo = gh.repository(args.github_org, args.github_repo)
     label = f"open.{args.labelled_version}"
-    repo.create_label(label, COLOR_OF_VERSION_LABELS)
+    create_label_if_not_exists(repo, label, COLOR_OF_VERSION_LABELS)
     print("Add the following line to your release notes on github:")
     section_title = "**Known bugs** and possible work arounds"
-    if add_label_to_open_bugs(repo, label):
+    if add_label_to_open_bugs(repo, label, dry_run=args.dry_run):
         msg = (
             f"{section_title}: [known bugs in {args.labelled_version}]"
             f"(https://github.com/{args.github_org}/{args.github_repo}/"


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->


## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

fixes https://github.com/NASA-PDS/lasso-issues/issues/11

