### PR TITLE
Upgrading to Python 3.13

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,14 +27,22 @@ repos:
 #         language: system
 #         pass_filenames: false
 
--   repo: local
-    hooks:
-    -   id: black
-        name: black
-        entry: black
-        files: ^src/|tests/
-        language: system
-        types: [python]
+# Disabling black because it's conflicting with reorder_python_imports. That
+# hook wants to add a blank line before the imports, and then black wants to
+# remove it.
+#
+# Choosing to prioritize reorder_python_imports hook since it can reduce
+# merge conflicts and black is too authoritarian.
+#
+# -   repo: local
+#     hooks:
+#     -   id: black
+#         name: black
+#         entry: black
+#         files: ^src/|tests/
+#         language: system
+#         types: [python]
+
 
 -   repo: local
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,8 +20,7 @@ url = https://github.com/NASA-PDS/lasso-issues
 download_url = https://github.com/NASA-PDS/lasso-issues/releases/
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
-    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python :: 3.13
     Operating System :: OS Independent
 
 
@@ -33,41 +32,48 @@ classifiers =
 
 [options]
 install_requires =
-    github3.py ~= 1.3.0  # OK for later versions here—github-actions-base (Roundup) doesn't use this lasso.issues
-    rstcloth ~= 0.5.6    # OK for later versions here—github-actions-base (Roundup) doesn't use this lasso.issues
-    pyzenhub ~= 0.3.1    # OK for later versions here—github-actions-base (Roundup) doesn't use this lasso.issues
-    mdutils ~= 1.2.2     # OK for later versions here—github-actions-base (Roundup) doesn't use this lasso.issues
-    pandas ~= 2.2.2
+    github3.py == 4.0.1  # Must match the version in github-actions-base
+    rstcloth ~= 0.6.0
+    pyzenhub ~= 0.3.2
+    mdutils ~= 1.8.0
+    pandas == 2.3.0      # Must match the version in github-actions-base
 
 # Change this to False if you use things like __file__ or __path__—which you
-# shouldn't use anyway, because that's what ``pkg_resources`` is for 🙂
+# shouldn't use anyway, because that's what ``importlib`` is for 🙂
 zip_safe = True
 include_package_data = True
-namespace_packages = lasso
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >= 3.9
+python_requires = >= 3.13
 
 [options.extras_require]
 dev =
-    black
-    flake8
-    flake8-bugbear
-    flake8-docstrings
-    pep8-naming
-    mypy
-    pydocstyle
-    coverage
-    pytest
-    pytest-cov
-    pytest-watch
-    pytest-xdist
-    pre-commit
-    sphinx
-    sphinx-rtd-theme
-    tox
-    types-setuptools
+    black~=23.7.0
+    flake8~=6.1.0
+    flake8-bugbear~=23.7.10
+    flake8-docstrings~=1.7.0
+    pep8-naming~=0.13.3
+    mypy~=1.5.1
+    pydocstyle~=6.3.0
+    coverage~=7.3.0
+    pytest~=7.4.0
+    pytest-cov~=4.1.0
+    pytest-watch~=4.2.0
+    pytest-xdist~=3.3.1
+    pre-commit~=3.3.3
+    sphinx~=8.2.3
+    sphinx-rtd-theme~=3.0.2
+    sphinxcontrib-applehelp~=2.0.0
+    sphinxcontrib-devhelp~=2.0.0
+    sphinxcontrib-htmlhelp~=2.1.0
+    sphinxcontrib.serializinghtml~=2.0.0
+    sphinxcontrib.qthelp~=2.0.0
+    alabaster~=1.0.0
+    tox~=4.11.0
+    types-setuptools~=68.1.0.0
+    Jinja2~=3.1.6
+
 
 [options.entry_points]
 console_scripts =

--- a/src/lasso/__init__.py
+++ b/src/lasso/__init__.py
@@ -1,4 +1,2 @@
 # encoding: utf-8
 """PDS "Lasso" 🤠 namespace."""
-
-__import__("pkg_resources").declare_namespace(__name__)

--- a/src/lasso/issues/__init__.py
+++ b/src/lasso/issues/__init__.py
@@ -1,4 +1,4 @@
 """Lasso Issues."""
 import importlib.resources
 
-__version__ = importlib.resources.files(__name__).joinpath("VERSION.txt").read_text().strip()
+__version__ = VERSION = importlib.resources.files(__name__).joinpath("VERSION.txt").read_text().strip()

--- a/src/lasso/issues/__init__.py
+++ b/src/lasso/issues/__init__.py
@@ -1,4 +1,4 @@
 """Lasso Issues."""
-import importlib
+import importlib.resources
 
 __version__ = importlib.resources.files(__name__).joinpath("VERSION.txt").read_text().strip()

--- a/src/lasso/issues/__init__.py
+++ b/src/lasso/issues/__init__.py
@@ -1,4 +1,4 @@
 """Lasso Issues."""
-import pkg_resources
+import importlib
 
-__version__ = VERSION = pkg_resources.resource_string(__name__, "VERSION.txt").decode("utf-8").strip()
+__version__ = importlib.resources.files(__name__).joinpath("VERSION.txt").read_text().strip()

--- a/src/lasso/issues/issues/RstRddReport.py
+++ b/src/lasso/issues/issues/RstRddReport.py
@@ -1027,7 +1027,11 @@ class CsvTestCaseReport(RddReport):
         except NoAcceptanceCriteriaFoundError:
             test_case_labels.append(f"AC{acn}")
             test_case_labels.append("draft")
-            acceptance_criteria = {"custom_steps": readable_issue_url, "custom_expected": "", "refs": ",".join(test_case_labels)}
+            acceptance_criteria = {
+                "custom_steps": readable_issue_url,
+                "custom_expected": "",
+                "refs": ",".join(test_case_labels),
+            }
             test_case.update(acceptance_criteria)
             self._post_test_case(issue_ref, acn, test_case, repo_name)
 

--- a/src/lasso/issues/issues/utils.py
+++ b/src/lasso/issues/issues/utils.py
@@ -1,4 +1,5 @@
 """Utilities."""
+
 ISSUE_TYPES = ["bug", "enhancement", "requirement", "theme"]
 TOP_PRIORITIES = ["p.must-have", "s.high", "s.critical"]
 IGNORE_LABELS = ["wontfix", "duplicate", "invalid"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, docs, lint
+envlist = py313, docs, lint
 isolated_build = True
 
 [testenv]
@@ -10,7 +10,7 @@ commands = pytest
 [testenv:docs]
 deps = .[dev]
 whitelist_externals = python
-commands = python setup.py build_sphinx
+commands = sphinx-build --builder html docs/source docs/build
 
 [testenv:lint]
 deps = pre-commit
@@ -19,6 +19,6 @@ commands=
 skip_install = true
 
 [testenv:dev]
-basepython = python3.9
+basepython = python3.13
 usedevelop = True
 deps = .[dev]


### PR DESCRIPTION
## 🗒️ Summary

Upgrades from supporting Python 3.9 to Python 3.13.

## ⚙️ Test Data and/or Report

This tool is used by the Roundup Action. See successful Roundup runs at

- Stable: https://github.com/nasa-pds-engineering-node/epitome/actions/runs/16601184002
- Unstable: https://github.com/nasa-pds-engineering-node/epitome/actions/runs/14842393866

## ♻️ Related Issues

- https://github.com/NASA-PDS/template-repo-python/issues/105