### PR TITLE
Fix flake8 error and warnings and also remove unsupported Sphinx option

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,7 +80,6 @@ html_css_files = [
 html_theme_options = {
     'canonical_url': '',
     'logo_only': False,
-    'display_version': True,
     'prev_next_buttons_location': 'bottom',
     'style_external_links': False,
     # Toc options

--- a/src/lasso/issues/issues/RstRddReport.py
+++ b/src/lasso/issues/issues/RstRddReport.py
@@ -873,7 +873,7 @@ class NoAcceptanceCriteriaFoundError(Exception):
 class CsvTestCaseReport(RddReport):
     """Report as test cases importable in test management software. Used with testrail."""
 
-    TEST_CASE_REFS_REGEX = ["B[0-9][0-9]\.[0-9]", "s\..*", "p\..*", "requirement", "bug", "i&t.automated"]  # noqa
+    TEST_CASE_REFS_REGEX = [r"B[0-9][0-9]\.[0-9]", r"s\..*", r"p\..*", r"requirement", r"bug", r"i&t.automated"]  # noqa
     # TODO make that an argument
     PROJECT_ID = 168
     # TODO make that an argument

--- a/src/lasso/issues/issues/utils.py
+++ b/src/lasso/issues/issues/utils.py
@@ -77,6 +77,7 @@ def is_theme(labels, zen_issue):
         if "theme" in labels:
             return True
 
+
 def issue_is_pull_request(issue_number, pull_request):
     """Check If Issue Is A Pull Request.
 


### PR DESCRIPTION
## 🗒️ Summary

While trying to do a stable release, the Roundup failed on the `flake8` step with the following:
```
src/lasso/issues/issues/RstRddReport.py:876: SyntaxWarning: invalid escape sequence '\.'
  TEST_CASE_REFS_REGEX = ["B[0-9][0-9]\.[0-9]", "s\..*", "p\..*", "requirement", "bug", "i&t.automated"]  # noqa
src/lasso/issues/issues/RstRddReport.py:876: SyntaxWarning: invalid escape sequence '\.'
  TEST_CASE_REFS_REGEX = ["B[0-9][0-9]\.[0-9]", "s\..*", "p\..*", "requirement", "bug", "i&t.automated"]  # noqa
src/lasso/issues/issues/RstRddReport.py:876: SyntaxWarning: invalid escape sequence '\.'
  TEST_CASE_REFS_REGEX = ["B[0-9][0-9]\.[0-9]", "s\..*", "p\..*", "requirement", "bug", "i&t.automated"]  # noqa
src/lasso/issues/issues/utils.py:80:1: E302 expected 2 blank lines, found 1
```
Merge this PR to fix this.

Bonus: the Sphinx docs were using `display_version` but it's no longer supported; it's removed.

## ⚙️ Test Data and/or Report

```
$ tox
…
  py313: OK (9.56=setup[8.21]+cmd[1.35] seconds)
  docs: OK (1.71=setup[1.34]+cmd[0.37] seconds)
  lint: OK (1.64=setup[0.00]+cmd[1.64] seconds)
  congratulations :) (12.97 seconds)
```

## ♻️ Related Issues

- See the [failed Roundup run](https://github.com/NASA-PDS/lasso-issues/actions/runs/17435691929)