### PR TITLE
Fix 502 errors by dropping repo: qualifiers from GitHub search queries

### DIFF
--- a/src/lasso/issues/activity/collector_issues.py
+++ b/src/lasso/issues/activity/collector_issues.py
@@ -132,11 +132,10 @@ def collect_issues(gh, org: str, repos, start_date: str, end_date: str) -> list:
     Returns:
         list[ActivityIssue]: Normalized issue records, sorted by (repo, number).
     """
-    # Build repo restriction suffix for search query
-    repo_qualifier = _build_repo_qualifier(org, repos)
+    repos_set = set(repos) if repos else None
 
-    # Search for closed issues in the date range
-    query = f"org:{org} is:issue is:closed closed:{start_date}..{end_date}{repo_qualifier}"
+    # Always query the whole org — repo: qualifiers balloon the URL and cause 502s at scale.
+    query = f"org:{org} is:issue is:closed closed:{start_date}..{end_date}"
     _logger.debug("Issue search query: %s", query)
 
     def _search_all():
@@ -149,6 +148,8 @@ def collect_issues(gh, org: str, repos, start_date: str, end_date: str) -> list:
             repo_name = _repo_name_from_url(search_issue.html_url)
             if not repo_name:
                 _logger.warning("Could not determine repo for issue %s", search_issue.html_url)
+                continue
+            if repos_set is not None and repo_name not in repos_set:
                 continue
             parent = get_parent_issue(gh, org, repo_name, search_issue.number)
             results.append(normalize_issue(search_issue, repo_name, parent=parent))
@@ -169,14 +170,6 @@ def collect_issues(gh, org: str, repos, start_date: str, end_date: str) -> list:
         )
     _logger.info("Collected %d closed issues", len(issues))
     return issues
-
-
-def _build_repo_qualifier(org: str, repos) -> str:
-    """Build a space-separated list of repo: qualifiers for a GitHub search query."""
-    if not repos:
-        return ''
-    parts = [f' repo:{org}/{r}' for r in repos]
-    return ''.join(parts)
 
 
 def _repo_name_from_url(html_url: str) -> str:

--- a/src/lasso/issues/activity/collector_prs.py
+++ b/src/lasso/issues/activity/collector_prs.py
@@ -7,7 +7,6 @@ import logging
 import github3.exceptions
 import requests.exceptions
 
-from lasso.issues.activity.collector_issues import _build_repo_qualifier
 from lasso.issues.activity.collector_issues import _repo_name_from_url
 from lasso.issues.activity.schema import ActivityPR
 from lasso.issues.activity.schema import normalize_pr
@@ -32,8 +31,9 @@ def collect_prs(gh, org: str, repos, start_date: str, end_date: str) -> list:
     Returns:
         list[ActivityPR]: Normalized PR records, sorted by (repo, number).
     """
-    repo_qualifier = _build_repo_qualifier(org, repos)
-    query = f"org:{org} is:pr is:merged merged:{start_date}..{end_date}{repo_qualifier}"
+    repos_set = set(repos) if repos else None
+    # Always query the whole org — repo: qualifiers balloon the URL and cause 502s at scale.
+    query = f"org:{org} is:pr is:merged merged:{start_date}..{end_date}"
     _logger.debug("PR search query: %s", query)
 
     prs: list[ActivityPR] = []
@@ -48,6 +48,8 @@ def collect_prs(gh, org: str, repos, start_date: str, end_date: str) -> list:
             repo_name = _repo_name_from_url(search_pr.html_url)
             if not repo_name:
                 _logger.warning("Could not determine repo for PR %s", search_pr.html_url)
+                continue
+            if repos_set is not None and repo_name not in repos_set:
                 continue
 
             pr_number = search_pr.number

--- a/tests/activity/test_collector_issues.py
+++ b/tests/activity/test_collector_issues.py
@@ -3,7 +3,6 @@ import unittest
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
-from lasso.issues.activity.collector_issues import _build_repo_qualifier
 from lasso.issues.activity.collector_issues import _repo_name_from_url
 from lasso.issues.activity.collector_issues import discover_repos
 from lasso.issues.activity.schema import normalize_issue
@@ -26,24 +25,6 @@ class TestRepoNameFromUrl(unittest.TestCase):
     def test_empty_string_returns_empty(self):
         self.assertEqual(_repo_name_from_url(""), "")
 
-
-class TestBuildRepoQualifier(unittest.TestCase):
-    """Tests for _build_repo_qualifier."""
-
-    def test_no_repos_returns_empty(self):
-        self.assertEqual(_build_repo_qualifier("NASA-PDS", None), "")
-
-    def test_empty_list_returns_empty(self):
-        self.assertEqual(_build_repo_qualifier("NASA-PDS", []), "")
-
-    def test_single_repo(self):
-        result = _build_repo_qualifier("NASA-PDS", ["validate"])
-        self.assertEqual(result, " repo:NASA-PDS/validate")
-
-    def test_multiple_repos(self):
-        result = _build_repo_qualifier("NASA-PDS", ["validate", "registry"])
-        self.assertIn("repo:NASA-PDS/validate", result)
-        self.assertIn("repo:NASA-PDS/registry", result)
 
 
 class TestNormalizeIssue(unittest.TestCase):


### PR DESCRIPTION
## Summary

- GitHub search queries with 130+ `repo:` qualifiers exceed the URL length limit, causing 502 Server Errors
- Both `collect_issues` and `collect_prs` now query `org:NASA-PDS` only and filter results by repo name in Python post-fetch
- Removes the dead `_build_repo_qualifier` helper and its unit tests

## Test plan

- [ ] Run `python -m pytest tests/activity/ -m "not integration" -v` — all 21 tests pass
- [ ] Run a real collection with a large repo list and confirm no 502 errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)